### PR TITLE
Fix example_cam.launch

### DIFF
--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -1,17 +1,21 @@
 <launch>
-    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam" output="screen">
-        <param name="serial_no"       type="string" value="UPCBS2110017" />
+    <arg name="serial_no" default="UPCBS2110017"/>
+    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam" output="log">
+        <param name="serial_no"       type="string" value="$(arg serial_no)" />
         <param name="cam_name"        type="string" value="ximea_cam" />
-        <param name="calib_file"      type="string" value="package://gripper_blaser_ros/cfg/ximea_info.yaml"         />
+        <!-- <param name="calib_file"      type="string" value="" /> -->
         <param name="frame_id"        type="string" value="0"        />
         <param name="num_cams_in_bus" type="int"    value="1"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
         <param name="publish_xi_image_info" type="bool" value="false"/>
         <param name="poll_time"       type="double" value="2.0"/>
         <param name="poll_time_frame" type="double" value="0.01"/>
-        <param name="exposure_time"   type="int"    vale="2000"/>
-        <param name="white_balance_mode"   type="int"    vale="0"/>
+        <param name="horizontal_flip"   type="bool"    value="true"/>
 
+        <!-- Good exposure parameter for just capture laser lines -->
+        <param name="exposure_time" type="int" value="10000"/>
+        <param name="white_balance_mode" type="int" value="0"/>
+        
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>
 </launch>


### PR DESCRIPTION
Replaced example_cam.launch with a previous version that works, because the current version crashes.